### PR TITLE
Add Elementor filter plugin skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# filter-elem
+# Filter Elem
+
+Ce dépôt contient un plugin WordPress minimal pour Elementor qui ajoute un widget permettant d'afficher les articles filtrés par catégorie.
+
+## Installation
+
+1. Copiez le dossier du plugin dans le répertoire `wp-content/plugins/` de votre site WordPress.
+2. Activez le plugin "Filter Elem" depuis l'interface d'administration WordPress.
+
+## Utilisation
+
+Après activation, un nouveau widget nommé **Filter Elem** apparaît dans l'éditeur Elementor. Choisissez une catégorie d'articles dans les options du widget pour afficher automatiquement la liste correspondante.
+
+## Développement
+
+Le code suit les normes WordPress (fonctionnement sans `?>`). Les fichiers principaux sont :
+
+- `filter-elem.php` : fichier principal du plugin.
+- `widgets/class-filter-elem-widget.php` : définition du widget Elementor.
+
+N'hésitez pas à adapter le code ou à ajouter des fonctionnalités supplémentaires selon vos besoins.

--- a/filter-elem.php
+++ b/filter-elem.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Plugin Name: Filter Elem
+ * Description: Adds filtering capabilities for an Elementor widget.
+ * Version: 1.0.0
+ * Author: Sulfamique
+ * Text Domain: filter-elem
+ * Domain Path: /languages
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+/**
+ * Main plugin class.
+ */
+class Filter_Elem {
+
+    /**
+     * Plugin instance.
+     *
+     * @var Filter_Elem
+     */
+    private static $instance = null;
+
+    /**
+     * Plugin version.
+     */
+    const VERSION = '1.0.0';
+
+    /**
+     * Get singleton instance.
+     *
+     * @return Filter_Elem
+     */
+    public static function get_instance() {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    /**
+     * Constructor.
+     */
+    private function __construct() {
+        add_action( 'init', array( $this, 'load_textdomain' ) );
+        add_action( 'elementor/widgets/register', array( $this, 'register_widgets' ) );
+    }
+
+    /**
+     * Load plugin textdomain for translations.
+     */
+    public function load_textdomain() {
+        load_plugin_textdomain( 'filter-elem', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+    }
+
+    /**
+     * Register Elementor widgets.
+     *
+     * @param \Elementor\Widgets_Manager $widgets_manager Widgets manager instance.
+     */
+    public function register_widgets( $widgets_manager ) {
+        require_once __DIR__ . '/widgets/class-filter-elem-widget.php';
+        $widgets_manager->register( new Filter_Elem_Widget() );
+    }
+}
+
+// Initialize the plugin.
+Filter_Elem::get_instance();

--- a/widgets/class-filter-elem-widget.php
+++ b/widgets/class-filter-elem-widget.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Filter Elem Widget for Elementor.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+use Elementor\Widget_Base;
+use Elementor\Controls_Manager;
+
+/**
+ * Class Filter_Elem_Widget
+ */
+class Filter_Elem_Widget extends Widget_Base {
+
+    /**
+     * Get widget name.
+     *
+     * @return string
+     */
+    public function get_name() {
+        return 'filter_elem_widget';
+    }
+
+    /**
+     * Get widget title.
+     *
+     * @return string
+     */
+    public function get_title() {
+        return __( 'Filter Elem', 'filter-elem' );
+    }
+
+    /**
+     * Get widget icon.
+     *
+     * @return string
+     */
+    public function get_icon() {
+        return 'eicon-filter';
+    }
+
+    /**
+     * Register widget controls.
+     */
+    protected function register_controls() {
+        $this->start_controls_section( 'section_content', array(
+            'label' => __( 'Content', 'filter-elem' ),
+        ) );
+
+        $this->add_control( 'category', array(
+            'label'   => __( 'Category', 'filter-elem' ),
+            'type'    => Controls_Manager::SELECT2,
+            'options' => $this->get_categories(),
+        ) );
+
+        $this->end_controls_section();
+    }
+
+    /**
+     * Render widget output on the frontend.
+     */
+    protected function render() {
+        $settings = $this->get_settings_for_display();
+        $query    = new WP_Query(
+            array(
+                'post_type' => 'post',
+                'cat'       => $settings['category'],
+            )
+        );
+
+        if ( $query->have_posts() ) {
+            echo '<ul class="filter-elem-posts">';
+            while ( $query->have_posts() ) {
+                $query->the_post();
+                echo '<li><a href="' . esc_url( get_permalink() ) . '">' . esc_html( get_the_title() ) . '</a></li>';
+            }
+            echo '</ul>';
+            wp_reset_postdata();
+        } else {
+            esc_html_e( 'No posts found', 'filter-elem' );
+        }
+    }
+
+    /**
+     * Helper to retrieve categories list.
+     *
+     * @return array
+     */
+    private function get_categories() {
+        $cats   = get_categories();
+        $result = array();
+        foreach ( $cats as $cat ) {
+            $result[ $cat->term_id ] = $cat->name;
+        }
+        return $result;
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement WordPress plugin `filter-elem.php`
- add Elementor widget implementation
- document usage in README

## Testing
- `php -l filter-elem.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431646dd9083249783c4d0918a0a4f