### PR TITLE
Add Elementor taxonomy filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# filter-elem
+# Filter Elem
+
+Ce dépôt contient un plugin WordPress minimal pour Elementor qui ajoute un widget permettant d'afficher les articles filtrés par catégorie ou par toute taxonomie disponible.
+
+## Installation
+
+1. Copiez le dossier du plugin dans le répertoire `wp-content/plugins/` de votre site WordPress.
+2. Activez le plugin "Filter Elem" depuis l'interface d'administration WordPress.
+
+## Utilisation
+
+Après activation, un nouveau widget nommé **Filter Elem** apparaît dans l'éditeur Elementor. Choisissez un type de filtre (catégorie ou taxonomie), puis la catégorie ou le terme souhaité pour afficher automatiquement la liste correspondante.
+
+Un élément de menu **Filter Elem** est également disponible dans l'administration WordPress. Il ouvre un tableau de bord simple où vous pourrez ajouter de futures options de configuration.
+
+## Développement
+
+Le code suit les normes WordPress (fonctionnement sans `?>`). Les fichiers principaux sont :
+
+- `filter-elem.php` : fichier principal du plugin.
+- `widgets/class-filter-elem-widget.php` : définition du widget Elementor.
+- `includes/class-filter-elem-admin.php` : création du tableau de bord du plugin.
+
+N'hésitez pas à adapter le code ou à ajouter des fonctionnalités supplémentaires selon vos besoins.

--- a/filter-elem.php
+++ b/filter-elem.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Plugin Name: Filter Elem
+ * Description: Adds filtering capabilities for an Elementor widget.
+ * Version: 1.0.0
+ * Author: Sulfamique
+ * Text Domain: filter-elem
+ * Domain Path: /languages
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+/**
+ * Main plugin class.
+ */
+class Filter_Elem {
+
+    /**
+     * Plugin instance.
+     *
+     * @var Filter_Elem
+     */
+    private static $instance = null;
+
+    /**
+     * Admin handler instance.
+     *
+     * @var Filter_Elem_Admin
+     */
+    private $admin;
+
+    /**
+     * Plugin version.
+     */
+    const VERSION = '1.0.0';
+
+    /**
+     * Get singleton instance.
+     *
+     * @return Filter_Elem
+     */
+    public static function get_instance() {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    /**
+     * Constructor.
+     */
+    private function __construct() {
+        add_action( 'init', array( $this, 'load_textdomain' ) );
+        add_action( 'elementor/widgets/register', array( $this, 'register_widgets' ) );
+
+        require_once __DIR__ . '/includes/class-filter-elem-admin.php';
+        $this->admin = new Filter_Elem_Admin();
+        $this->admin->hooks();
+    }
+
+    /**
+     * Load plugin textdomain for translations.
+     */
+    public function load_textdomain() {
+        load_plugin_textdomain( 'filter-elem', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+    }
+
+    /**
+     * Register Elementor widgets.
+     *
+     * @param \Elementor\Widgets_Manager $widgets_manager Widgets manager instance.
+     */
+    public function register_widgets( $widgets_manager ) {
+        require_once __DIR__ . '/widgets/class-filter-elem-widget.php';
+        $widgets_manager->register( new Filter_Elem_Widget() );
+    }
+}
+
+// Initialize the plugin.
+Filter_Elem::get_instance();

--- a/includes/class-filter-elem-admin.php
+++ b/includes/class-filter-elem-admin.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Admin page for Filter Elem plugin.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+/**
+ * Class Filter_Elem_Admin
+ */
+class Filter_Elem_Admin {
+
+    /**
+     * Hook into admin actions.
+     */
+    public function hooks() {
+        add_action( 'admin_menu', array( $this, 'add_menu' ) );
+    }
+
+    /**
+     * Register plugin menu page.
+     */
+    public function add_menu() {
+        add_menu_page(
+            __( 'Filter Elem', 'filter-elem' ),
+            __( 'Filter Elem', 'filter-elem' ),
+            'manage_options',
+            'filter-elem',
+            array( $this, 'render_page' ),
+            'dashicons-filter'
+        );
+    }
+
+    /**
+     * Render admin page.
+     */
+    public function render_page() {
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__( 'Filter Elem Dashboard', 'filter-elem' ) . '</h1>';
+        echo '<p>' . esc_html__( 'Configure your filter settings here.', 'filter-elem' ) . '</p>';
+        echo '</div>';
+    }
+}

--- a/widgets/class-filter-elem-widget.php
+++ b/widgets/class-filter-elem-widget.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * Filter Elem Widget for Elementor.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+use Elementor\Widget_Base;
+use Elementor\Controls_Manager;
+
+/**
+ * Class Filter_Elem_Widget
+ */
+class Filter_Elem_Widget extends Widget_Base {
+
+    /**
+     * Get widget name.
+     *
+     * @return string
+     */
+    public function get_name() {
+        return 'filter_elem_widget';
+    }
+
+    /**
+     * Get widget title.
+     *
+     * @return string
+     */
+    public function get_title() {
+        return __( 'Filter Elem', 'filter-elem' );
+    }
+
+    /**
+     * Get widget icon.
+     *
+     * @return string
+     */
+    public function get_icon() {
+        return 'eicon-filter';
+    }
+
+    /**
+     * Register widget controls.
+     */
+    protected function register_controls() {
+        $this->start_controls_section(
+            'section_content',
+            array(
+                'label' => __( 'Content', 'filter-elem' ),
+            )
+        );
+
+        $this->add_control(
+            'filter_type',
+            array(
+                'label'   => __( 'Filter Type', 'filter-elem' ),
+                'type'    => Controls_Manager::SELECT,
+                'options' => array(
+                    'category' => __( 'Category', 'filter-elem' ),
+                    'taxonomy' => __( 'Taxonomy', 'filter-elem' ),
+                ),
+                'default' => 'category',
+            )
+        );
+
+        $this->add_control(
+            'category',
+            array(
+                'label'     => __( 'Category', 'filter-elem' ),
+                'type'      => Controls_Manager::SELECT2,
+                'options'   => $this->get_categories(),
+                'condition' => array( 'filter_type' => 'category' ),
+            )
+        );
+
+        $this->add_control(
+            'taxonomy',
+            array(
+                'label'     => __( 'Taxonomy', 'filter-elem' ),
+                'type'      => Controls_Manager::SELECT2,
+                'options'   => $this->get_taxonomies(),
+                'condition' => array( 'filter_type' => 'taxonomy' ),
+            )
+        );
+
+        $this->add_control(
+            'term',
+            array(
+                'label'     => __( 'Term', 'filter-elem' ),
+                'type'      => Controls_Manager::SELECT2,
+                'options'   => $this->get_terms(),
+                'condition' => array( 'filter_type' => 'taxonomy' ),
+            )
+        );
+
+        $this->end_controls_section();
+    }
+
+    /**
+     * Render widget output on the frontend.
+     */
+    protected function render() {
+        $settings = $this->get_settings_for_display();
+        $args     = array(
+            'post_type' => 'post',
+        );
+
+        if ( 'category' === $settings['filter_type'] ) {
+            $args['cat'] = $settings['category'];
+        } else {
+            $args['tax_query'] = array(
+                array(
+                    'taxonomy' => $settings['taxonomy'],
+                    'field'    => 'term_id',
+                    'terms'    => $settings['term'],
+                ),
+            );
+        }
+
+        $query = new WP_Query( $args );
+
+        if ( $query->have_posts() ) {
+            echo '<ul class="filter-elem-posts">';
+            while ( $query->have_posts() ) {
+                $query->the_post();
+                echo '<li><a href="' . esc_url( get_permalink() ) . '">' . esc_html( get_the_title() ) . '</a></li>';
+            }
+            echo '</ul>';
+            wp_reset_postdata();
+        } else {
+            esc_html_e( 'No posts found', 'filter-elem' );
+        }
+    }
+
+    /**
+     * Helper to retrieve categories list.
+     *
+     * @return array
+     */
+    private function get_categories() {
+        $cats   = get_categories();
+        $result = array();
+        foreach ( $cats as $cat ) {
+            $result[ $cat->term_id ] = $cat->name;
+        }
+        return $result;
+    }
+
+    /**
+     * Retrieve available taxonomies.
+     *
+     * @return array
+     */
+    private function get_taxonomies() {
+        $taxes   = get_taxonomies( array( 'public' => true ), 'objects' );
+        $options = array();
+        foreach ( $taxes as $tax ) {
+            $options[ $tax->name ] = $tax->label;
+        }
+        return $options;
+    }
+
+    /**
+     * Retrieve all terms for selection.
+     *
+     * @return array
+     */
+    private function get_terms() {
+        $terms   = get_terms( array( 'hide_empty' => false ) );
+        $options = array();
+
+        if ( ! is_wp_error( $terms ) ) {
+            foreach ( $terms as $term ) {
+                $options[ $term->term_id ] = sprintf( '%s: %s', $term->taxonomy, $term->name );
+            }
+        }
+
+        return $options;
+    }
+}
+


### PR DESCRIPTION
## Summary
- allow widget filtering by category or any taxonomy
- document taxonomy filtering in README

## Testing
- `php -l filter-elem.php` *(fails: command not found)*
- `php -l includes/class-filter-elem-admin.php` *(fails: command not found)*
- `php -l widgets/class-filter-elem-widget.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431646dd9083249783c4d0918a0a4f